### PR TITLE
Fix file extension for template projection

### DIFF
--- a/plugin/phoenix.vim
+++ b/plugin/phoenix.vim
@@ -55,7 +55,7 @@ let s:projections = {
   \ "test/models/*_test.exs": {
   \   "alternate": "web/models/{}.ex"
   \ },
-  \ "web/templates/*.html.exs": {
+  \ "web/templates/*.html.eex": {
   \   "type": "template"
   \ },
   \ "web/router.ex": {


### PR DESCRIPTION
This extension should be eex rather than exs.

Thanks for the plugin!
